### PR TITLE
Fixed first and last item snap behavior

### DIFF
--- a/app/src/main/java/com/github/rubensousa/recyclerviewsnap/GravitySnapHelper.java
+++ b/app/src/main/java/com/github/rubensousa/recyclerviewsnap/GravitySnapHelper.java
@@ -43,7 +43,7 @@ public class GravitySnapHelper extends LinearSnapHelper {
         int[] out = new int[2];
 
         if (layoutManager.canScrollHorizontally()) {
-            if (mGravity == Gravity.START) {
+            if (isStartGravity(layoutManager)) {
                 out[0] = distanceToStart(targetView, getHorizontalHelper(layoutManager));
             } else { // END
                 out[0] = distanceToEnd(targetView, getHorizontalHelper(layoutManager));
@@ -53,7 +53,7 @@ public class GravitySnapHelper extends LinearSnapHelper {
         }
 
         if (layoutManager.canScrollVertically()) {
-            if (mGravity == Gravity.TOP) {
+            if (isStartGravity(layoutManager)) {
                 out[1] = distanceToStart(targetView, getVerticalHelper(layoutManager));
             } else { // BOTTOM
                 out[1] = distanceToEnd(targetView, getVerticalHelper(layoutManager));
@@ -67,19 +67,29 @@ public class GravitySnapHelper extends LinearSnapHelper {
     @Override
     public View findSnapView(RecyclerView.LayoutManager layoutManager) {
         if (layoutManager instanceof LinearLayoutManager) {
-            switch (mGravity) {
-                case Gravity.START:
-                    return findStartView(layoutManager, getHorizontalHelper(layoutManager));
-                case Gravity.TOP:
-                    return findStartView(layoutManager, getVerticalHelper(layoutManager));
-                case Gravity.END:
-                    return findEndView(layoutManager, getHorizontalHelper(layoutManager));
-                case Gravity.BOTTOM:
-                    return findEndView(layoutManager, getVerticalHelper(layoutManager));
+            OrientationHelper helper = layoutManager.canScrollHorizontally()
+                    ? getHorizontalHelper(layoutManager) : getVerticalHelper(layoutManager);
+
+            if (isStartGravity(layoutManager)) {
+                return findStartView(layoutManager, helper);
+            } else {
+                return findEndView(layoutManager, helper);
             }
         }
 
         return super.findSnapView(layoutManager);
+    }
+
+    private boolean isStartGravity(RecyclerView.LayoutManager layoutManager) {
+        int firstCompletelyChild = ((LinearLayoutManager) layoutManager)
+                .findFirstCompletelyVisibleItemPosition();
+        int lastCompletelyChild = ((LinearLayoutManager) layoutManager)
+                .findLastCompletelyVisibleItemPosition();
+
+        return (mGravity == Gravity.START || mGravity == Gravity.TOP)
+                    && lastCompletelyChild != layoutManager.getItemCount() - 1
+                || (mGravity == Gravity.END || mGravity == Gravity.BOTTOM)
+                    && firstCompletelyChild == 0;
     }
 
     private int distanceToStart(View targetView, OrientationHelper helper) {


### PR DESCRIPTION
I was going to fix first and last item snap behavior.

Now, the last item of `Gravity.START` and `Gravity.TOP` can't show completely.
Below is the screen shot:
<img src="https://cloud.githubusercontent.com/assets/4586632/18408178/c47cdb1c-7762-11e6-9fd8-5c8d528f57f3.gif" width="270">

And the first item of `Gravity.END` and `GRAVITY.BOTTOM` have a same issue.
I was going to fix it.
