### PR TITLE
Use api instead of implementation

### DIFF
--- a/gravitysnaphelper/build.gradle
+++ b/gravitysnaphelper/build.gradle
@@ -12,7 +12,7 @@ android {
 }
 
 dependencies {
-    implementation "com.android.support:recyclerview-v7:$rootProject.ext.supportLibVersion"
+    api "com.android.support:recyclerview-v7:$rootProject.ext.supportLibVersion"
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')


### PR DESCRIPTION
@rubensousa oops, minor mistake here. If we don't use api, devs will get a compilation error when trying to use this library if they don't have the recycler view dep themselves.