### PR TITLE
Work around for https://issuetracker.google.com/issues/37019979

### DIFF
--- a/gravitysnaphelper/src/main/java/com/github/rubensousa/gravitysnaphelper/GravityDelegate.java
+++ b/gravitysnaphelper/src/main/java/com/github/rubensousa/gravitysnaphelper/GravityDelegate.java
@@ -277,10 +277,13 @@ class GravityDelegate {
         RecyclerView.LayoutManager layoutManager = recyclerView.getLayoutManager();
 
         if (layoutManager instanceof LinearLayoutManager) {
+            LinearLayoutManager linearLayoutManager = (LinearLayoutManager)layoutManager;
             if (gravity == Gravity.START || gravity == Gravity.TOP) {
-                return ((LinearLayoutManager) layoutManager).findFirstCompletelyVisibleItemPosition();
+                int pos = linearLayoutManager.findFirstCompletelyVisibleItemPosition();
+                return (pos != RecyclerView.NO_POSITION) ? pos : linearLayoutManager.findFirstVisibleItemPosition();
             } else if (gravity == Gravity.END || gravity == Gravity.BOTTOM) {
-                return ((LinearLayoutManager) layoutManager).findLastCompletelyVisibleItemPosition();
+                int pos = linearLayoutManager.findLastCompletelyVisibleItemPosition();
+                return (pos != RecyclerView.NO_POSITION) ? pos : linearLayoutManager.findLastVisibleItemPosition();
             }
         }
 


### PR DESCRIPTION
Fallback to findFirstVisibleItemPosition if findFirstCompletelyVisibleItemPosition is reporting NO_POSITION to handle recyclerviews that have enough padding to be able to snap all items  (https://github.com/rubensousa/RecyclerViewSnap/issues/49)